### PR TITLE
Add igraph to docs/requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ sphinx-rtd-theme == 0.5.2
 sphinxcontrib-plantuml >= 0.21
 sphinxcontrib-needs == 0.7.0
 funcparserlib == 1.0.0
+igraph


### PR DESCRIPTION
The latest changes to Raider added a dependency on the Python igraph module. docs/requirements must be updated so that Sphinx can run autodoc.