### PR TITLE
feat : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM        python:3.10
 MAINTAINER  Daniel Neagaru <daniel@neagaru.com>
 
 ADD . /opt/raider/
-RUN pip3 install -e /opt/raider
+RUN pip3 install --no-cache-dir -e /opt/raider
 RUN mkdir -p /root/.config/raider/projects
 
 VOLUME ["/root/.config/raider"]


### PR DESCRIPTION
using the "--no-cache-dir" flag in pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>